### PR TITLE
Shortened the import statements by using __init__.py 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Which currently outputs the MTTF of an arbitrary 2x2 heterogeneous design point 
 ## Quickstart
 - [Designing an embedded system](src/design/README.md)
 - [Evaluate a single design point with the simulator](src/simulation/README.md)
-- [Evaluating multiple design points via Monte Carlo simulation](src/dse/README.md)
+- [Evaluating multiple design points via Monte Carlo simulation](src/DSE/README.md)
 
 ## Contributing
 For information about contributing to this project, see [CONTRIBUTING](CONTRIBUTING.md)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ scipy==1.4.1
 six==1.14.0
 wcwidth==0.1.9
 zipp==3.1.0
+deap==1.3.1

--- a/src/DSE/README.md
+++ b/src/DSE/README.md
@@ -6,6 +6,8 @@ designpoints = [DesignPoint.create_random(k) for _ in range(n)]
 ```
 Given this list of designpoints, we can evaluate these via:
 ```python
+from DSE import monte_carlo
+
 monte_carlo(designpoints, iterations=10000, parallelized=True)
 ```
 It is advised to use the parallelized version of the Monte Carlo simulation for performance purposes.
@@ -16,9 +18,9 @@ will print the MTTF of this Design Point per every 10% workload increase.
 ```python
 import numpy as np
 
-from design.designpoint import DesignPoint
+from design import DesignPoint
 from design.mapping import all_possible_pos_mappings
-from dse.montecarlo import monte_carlo
+from DSE import monte_carlo
 
 dps = []
 n = 2

--- a/src/DSE/__init__.py
+++ b/src/DSE/__init__.py
@@ -1,0 +1,1 @@
+from .montecarlo import monte_carlo

--- a/src/DSE/montecarlo.py
+++ b/src/DSE/montecarlo.py
@@ -7,7 +7,7 @@ import math
 import multiprocessing
 import warnings
 
-from simulation.simulator import Simulator
+from simulation import Simulator
 
 __licence__ = "GPL-3.0-or-later"
 __copyright__ = "Copyright 2020 Siard Keulen"

--- a/src/design/README.md
+++ b/src/design/README.md
@@ -13,9 +13,9 @@ design point can be created to make up a design point.
 
 ### Import statements
 ```python
-from design.application import Application
-from design.component import Component
-from design.designpoint import DesignPoint
+from design import Application
+from design import Component
+from design import DesignPoint
 ```
 
 ### Components
@@ -94,10 +94,10 @@ The default policy (when no policy is specified) is set to random, but it can al
 Instead of doing all previous steps manually, it is possible to create designpoints in a direct way, for example:
 ```python
 DesignPoint.create(capacities=[100, 120], 
-                               locs=[(1, 1), (0, 1)],
-                               apps=[50, 40], 
-                               mapping=[(0, 0), (1,1)],
-                               policy='random')
+                   locs=[(1, 1), (0, 1)],
+                   apps=[50, 40], 
+                   mapping=[(0, 0), (1,1)],
+                   policy='random')
 ```
 will do all previous steps in a single statement. All the arguments of this functions are corresponding index-wise. 
 

--- a/src/design/__init__.py
+++ b/src/design/__init__.py
@@ -1,0 +1,3 @@
+from .application import Application
+from .component import Component
+from .designpoint import DesignPoint

--- a/src/design/designpoint.py
+++ b/src/design/designpoint.py
@@ -11,8 +11,8 @@ A design point for an adaptive embedded system consists of:
 import numpy as np
 import random
 
-from design.application import Application
-from design.component import Component
+from design import Application
+from design import Component
 from design.mapping import comp_to_loc_mapping, application_mapping, all_possible_pos_mappings
 
 __licence__ = "GPL-3.0-or-later"

--- a/src/main.py
+++ b/src/main.py
@@ -2,14 +2,14 @@
 
 """ This file is currently mainly used for testing/debugging purposes
 
-Use src/dse/montecarlo.py instead for the evaluation of design points.
+Use src/DSE/montecarlo.py instead for the evaluation of design points.
 """
 
 import numpy as np
 
-from design.designpoint import DesignPoint
+from design import DesignPoint
 from design.mapping import all_possible_pos_mappings
-from dse.montecarlo import monte_carlo
+from DSE import monte_carlo
 
 __licence__ = "GPL-3.0-or-later"
 __copyright__ = "Copyright 2020 Siard Keulen"

--- a/src/simulation/README.md
+++ b/src/simulation/README.md
@@ -10,7 +10,7 @@ dp = DesignPoint(components, applications, app_map)
 Once a design point is created, the simulator can be used in order to calculate the Time To Failure (TTF) 
 of that design point. All that the simulator requires is a designpoint, which can be initialized as:
 ```python
-from simulation.simulator import Simulator
+from simulation import Simulator
 
 sim = simulator.Simulator(dp)
 sim.run()

--- a/src/simulation/__init__.py
+++ b/src/simulation/__init__.py
@@ -1,0 +1,2 @@
+from .simulator import Simulator
+from .integrator import Integrator, AbsSimulator

--- a/src/simulation/elements/__init__.py
+++ b/src/simulation/elements/__init__.py
@@ -1,0 +1,4 @@
+from .agings import Agings
+from .components import Components
+from .thermals import Thermals
+from .element import SimulatorElement

--- a/src/simulation/elements/agings.py
+++ b/src/simulation/elements/agings.py
@@ -7,8 +7,8 @@ Agings are stored as a 2D numpy float array.
 
 import numpy as np
 
-from simulation.elements.element import SimulatorElement
-from simulation.faultmodels.electromigration import electro_migration
+from .element import SimulatorElement
+from simulation.faultmodels import electro_migration
 
 __licence__ = "GPL-3.0-or-later"
 __copyright__ = "Copyright 2020 Siard Keulen"

--- a/src/simulation/elements/components.py
+++ b/src/simulation/elements/components.py
@@ -8,7 +8,7 @@ The variables of components are spatially stored as a 2D numpy float arrayS.
 import numpy as np
 import warnings
 
-from simulation.elements.element import SimulatorElement
+from .element import SimulatorElement
 
 __licence__ = "GPL-3.0-or-later"
 __copyright__ = "Copyright 2020 Siard Keulen"

--- a/src/simulation/elements/thermals.py
+++ b/src/simulation/elements/thermals.py
@@ -8,7 +8,7 @@ Thermals are stored as a 2D numpy float array.
 import numpy as np
 from scipy import signal
 
-from simulation.elements.element import SimulatorElement
+from .element import SimulatorElement
 
 __licence__ = "GPL-3.0-or-later"
 __copyright__ = "Copyright 2020 Siard Keulen"

--- a/src/simulation/faultmodels/__init__.py
+++ b/src/simulation/faultmodels/__init__.py
@@ -1,0 +1,1 @@
+from .electromigration import electro_migration

--- a/src/simulation/integrator.py
+++ b/src/simulation/integrator.py
@@ -6,15 +6,14 @@ This file should describe how the Simulator elements are integrated with eachoth
 to run the simulation.
 """
 
-import copy
 import os
 
 import numpy as np
 from abc import ABC, abstractmethod
 
-from simulation.elements.thermals import Thermals
-from simulation.elements.agings import Agings
-from simulation.elements.components import Components
+from simulation.elements import Thermals
+from simulation.elements import Agings
+from simulation.elements import Components
 
 __licence__ = "GPL-3.0-or-later"
 __copyright__ = "Copyright 2020 Siard Keulen"

--- a/src/simulation/simulator.py
+++ b/src/simulation/simulator.py
@@ -7,7 +7,7 @@ Functionalities of the simulator should be defined in the integrator.py file.
 
 import sys
 
-from simulation.integrator import Integrator, AbsSimulator
+from .integrator import Integrator, AbsSimulator
 
 
 __licence__ = "GPL-3.0-or-later"

--- a/tests/design/test_application.py
+++ b/tests/design/test_application.py
@@ -1,7 +1,7 @@
 import pytest
 import random
 
-from design.application import Application
+from design import Application
 
 
 class TestApplication:

--- a/tests/design/test_component.py
+++ b/tests/design/test_component.py
@@ -1,7 +1,7 @@
 import pytest
 import random
 
-from design.component import Component
+from design import Component
 
 
 class TestComponent:

--- a/tests/design/test_designpoint.py
+++ b/tests/design/test_designpoint.py
@@ -1,9 +1,9 @@
 import pytest
 import numpy as np
 
-from design.application import Application
-from design.component import Component
-from design.designpoint import DesignPoint
+from design import Application
+from design import Component
+from design import DesignPoint
 
 
 class TestDesignpoint:

--- a/tests/design/test_mapping.py
+++ b/tests/design/test_mapping.py
@@ -2,8 +2,8 @@ import pytest
 import numpy as np
 import random
 
-from design.application import Application
-from design.component import Component
+from design import Application
+from design import Component
 from design.mapping import comp_to_loc_mapping, application_mapping
 
 

--- a/tests/dse/test_montecarlo.py
+++ b/tests/dse/test_montecarlo.py
@@ -1,8 +1,8 @@
 import time
 import pytest
 
-from design.designpoint import DesignPoint
-from dse.montecarlo import monte_carlo
+from design import DesignPoint
+from DSE import monte_carlo
 
 
 class TestMonteCarlo:

--- a/tests/simulation/test_elements_agings.py
+++ b/tests/simulation/test_elements_agings.py
@@ -5,10 +5,10 @@ import pytest
 # - aging for all locs with no component is 0
 # - aging for all components > 1 results in system failure
 # - thermals 0 means no aging
-from design.application import Application
-from design.component import Component
-from design.designpoint import DesignPoint
-from simulation.simulator import Simulator
+from design import Application
+from design import Component
+from design import DesignPoint
+from simulation import Simulator
 
 import numpy as np
 

--- a/tests/simulation/test_elements_components.py
+++ b/tests/simulation/test_elements_components.py
@@ -1,10 +1,10 @@
 import pytest
 import numpy as np
 
-from design.application import Application
-from design.component import Component
-from design.designpoint import DesignPoint
-from simulation.elements.components import Components
+from design import Application
+from design import Component
+from design import DesignPoint
+from simulation.elements import Components
 
 
 class TestComponents:

--- a/tests/simulation/test_simulator.py
+++ b/tests/simulation/test_simulator.py
@@ -1,9 +1,9 @@
 import pytest
 
-from design.application import Application
-from design.component import Component
-from design.designpoint import DesignPoint
-from simulation.simulator import Simulator
+from design import Application
+from design import Component
+from design import DesignPoint
+from simulation import Simulator
 
 
 class TestSimulator:


### PR DESCRIPTION
Made the import statements more logical, e.g.:

OLD:
```python
from design.application import Application
from simulation.simulator import Simulator
```

NEW:
```python
from design import Application
from simulation import Simulator
```